### PR TITLE
Elimiante direct calls to parent window

### DIFF
--- a/js/customize-partial-refresh-widgets-pane.js
+++ b/js/customize-partial-refresh-widgets-pane.js
@@ -16,6 +16,8 @@ wp.customize.partialPreviewWidgets = ( function ( $, api ) {
 
 	self.ready.done( function () {
 		api.previewer.bind( 'request-setting-transports', self.sendSettingTransports );
+		api.previewer.bind( 'update-setting', self.updateSetting );
+		api.previewer.bind( 'update-control', self.updateControl );
 	} );
 
 	/**
@@ -27,6 +29,62 @@ wp.customize.partialPreviewWidgets = ( function ( $, api ) {
 			transports[ setting.id ] = setting.transport;
 		} );
 		api.previewer.send( 'setting-transports', transports );
+	};
+
+	/**
+	 *
+	 * @param {wp.customize.Class} instance
+	 * @param {object} params
+	 * @param {string} params.id
+	 * @private
+	 */
+	self._updateInstance = function ( instance, params ) {
+		params = $.extend( {}, params );
+		delete params.id;
+		_.each( params, function ( value, key ) {
+			if ( '_' === key.substr( 0, 1 ) ) {
+				throw new Error( 'Attempted to update private property.' );
+			}
+
+			var existingProp = instance[ key ];
+			if ( existingProp && existingProp.extended && existingProp.extended( wp.customize.Value ) ) {
+				existingProp.set( value );
+			} else {
+				instance[ key ] = value;
+			}
+		} );
+	};
+
+	/**
+	 * Update a setting instance.
+	 *
+	 * @param {object} params
+	 * @param {string} params.id
+	 * @param {boolean} params.transport
+	 */
+	self.updateSetting = function ( params ) {
+		if ( ! params.id ) {
+			throw new Error( 'Missing setting id' );
+		}
+		wp.customize( params.id, function ( setting ) {
+			self._updateInstance( setting, params );
+		} );
+	};
+
+	/**
+	 * Update a control instance.
+	 *
+	 * @param {object} params
+	 * @param {string} params.id
+	 * @param {boolean} params.active
+	 */
+	self.updateControl = function ( params ) {
+		if ( ! params.id ) {
+			throw new Error( 'Missing control id' );
+		}
+		wp.customize.control( params.id, function ( control ) {
+			self._updateInstance( control, params );
+		} );
 	};
 
 	/**


### PR DESCRIPTION
Allow preview to update properties on settings and controls in the Customizer pane

Fixes #2