### PR TITLE
Encapsulate PHP and JS into selective_refresh and selectiveRefresh namespaces

### DIFF
--- a/js/customize-preview-nav-menus.js
+++ b/js/customize-preview-nav-menus.js
@@ -20,10 +20,10 @@ wp.customize.navMenusPreview = wp.customize.MenusCustomizerPreview = ( function(
 	 * Partial representing an invocation of wp_nav_menu().
 	 *
 	 * @class
-	 * @augments wp.customize.Partial
+	 * @augments wp.customize.selectiveRefresh.Partial
 	 * @since 4.5.0
 	 */
-	self.NavMenuInstancePartial = api.Partial.extend({
+	self.NavMenuInstancePartial = api.selectiveRefresh.Partial.extend({
 
 		/**
 		 * Constructor.
@@ -55,7 +55,7 @@ wp.customize.navMenusPreview = wp.customize.MenusCustomizerPreview = ( function(
 				},
 				options.params || {}
 			);
-			api.Partial.prototype.initialize.call( partial, id, options );
+			api.selectiveRefresh.Partial.prototype.initialize.call( partial, id, options );
 
 			if ( ! _.isObject( partial.params.navMenuArgs ) ) {
 				throw new Error( 'Missing navMenuArgs' );
@@ -111,7 +111,7 @@ wp.customize.navMenusPreview = wp.customize.MenusCustomizerPreview = ( function(
 		 */
 		renderContent: function( placement ) {
 			var partial = this, previousContainer = placement.container;
-			if ( api.Partial.prototype.renderContent.call( partial, placement ) ) {
+			if ( api.selectiveRefresh.Partial.prototype.renderContent.call( partial, placement ) ) {
 
 				// Trigger deprecated event.
 				$( document ).trigger( 'customize-preview-menu-refreshed', [ {
@@ -125,7 +125,7 @@ wp.customize.navMenusPreview = wp.customize.MenusCustomizerPreview = ( function(
 		}
 	});
 
-	api.partialConstructor.nav_menu_instance = self.NavMenuInstancePartial;
+	api.selectiveRefresh.partialConstructor.nav_menu_instance = self.NavMenuInstancePartial;
 
 	/**
 	 * Connect nav menu items with their corresponding controls in the pane.
@@ -170,7 +170,7 @@ wp.customize.navMenusPreview = wp.customize.MenusCustomizerPreview = ( function(
 				return;
 			}
 			themeLocation = matches[1];
-			api.partial.each( function( partial ) {
+			api.selectiveRefresh.partial.each( function( partial ) {
 				if ( partial.extended( self.NavMenuInstancePartial ) && partial.params.navMenuArgs.theme_location === themeLocation ) {
 					partial.refresh();
 					themeLocationPartialFound = true;

--- a/js/customize-preview-widgets.js
+++ b/js/customize-preview-widgets.js
@@ -151,7 +151,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 			} );
 
 			// Trigger an event for this sidebar being updated whenever a widget inside is rendered.
-			api.bind( 'partial-content-rendered', function( placement ) {
+			api.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 				var isAssignedWidgetPartial = (
 					placement.partial.extended( self.WidgetInstancePartial ) &&
 					( -1 !== _.indexOf( sidebarPartial.getWidgetIds(), placement.partial.widgetId ) )

--- a/js/customize-preview-widgets.js
+++ b/js/customize-preview-widgets.js
@@ -42,10 +42,10 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 	 * @todo Rename this to just WidgetPartial?
 	 *
 	 * @class
-	 * @augments wp.customize.Partial
+	 * @augments wp.customize.selectiveRefresh.Partial
 	 * @since 4.5.0
 	 */
-	self.WidgetInstancePartial = api.Partial.extend({
+	self.WidgetInstancePartial = api.selectiveRefresh.Partial.extend({
 
 		/**
 		 * Constructor.
@@ -74,7 +74,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 				options.params || {}
 			);
 
-			api.Partial.prototype.initialize.call( partial, id, options );
+			api.selectiveRefresh.Partial.prototype.initialize.call( partial, id, options );
 		},
 
 		/**
@@ -85,9 +85,9 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 		 */
 		renderContent: function( placement ) {
 			var partial = this;
-			if ( api.Partial.prototype.renderContent.call( partial, placement ) ) {
+			if ( api.selectiveRefresh.Partial.prototype.renderContent.call( partial, placement ) ) {
 				api.preview.send( 'widget-updated', partial.widgetId );
-				api.trigger( 'widget-updated', partial );
+				api.selectiveRefresh.trigger( 'widget-updated', partial );
 			}
 		}
 	});
@@ -98,10 +98,10 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 	 * @todo Rename this to SidebarPartial?
 	 *
 	 * @class
-	 * @augments wp.customize.Partial
+	 * @augments wp.customize.selectiveRefresh.Partial
 	 * @since 4.5.0
 	 */
-	self.WidgetAreaPartial = api.Partial.extend({
+	self.WidgetAreaPartial = api.selectiveRefresh.Partial.extend({
 
 		/**
 		 * Constructor.
@@ -127,7 +127,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 				options.params || {}
 			);
 
-			api.Partial.prototype.initialize.call( partial, id, options );
+			api.selectiveRefresh.Partial.prototype.initialize.call( partial, id, options );
 
 			if ( ! partial.params.sidebarArgs ) {
 				throw new Error( 'The sidebarArgs param was not provided.' );
@@ -157,7 +157,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 					( -1 !== _.indexOf( sidebarPartial.getWidgetIds(), placement.partial.widgetId ) )
 				);
 				if ( isAssignedWidgetPartial ) {
-					api.trigger( 'sidebar-updated', sidebarPartial );
+					api.selectiveRefresh.trigger( 'sidebar-updated', sidebarPartial );
 				}
 			} );
 
@@ -277,7 +277,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 
 			widgetPartials = {};
 			_.each( widgetIds, function( widgetId ) {
-				var widgetPartial = api.partial( 'widget_instance[' + widgetId + ']' );
+				var widgetPartial = api.selectiveRefresh.partial( 'widget_instance[' + widgetId + ']' );
 				if ( widgetPartial ) {
 					widgetPartials[ widgetId ] = widgetPartial;
 				}
@@ -313,7 +313,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 						);
 
 						// @todo Rename partial-placement-moved?
-						api.trigger( 'partial-content-moved', sidebarWidget.placement );
+						api.selectiveRefresh.trigger( 'partial-content-moved', sidebarWidget.placement );
 					} );
 
 					sortedSidebarContainers.push( sidebarPlacement );
@@ -321,7 +321,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 			} );
 
 			if ( sortedSidebarContainers.length > 0 ) {
-				api.trigger( 'sidebar-updated', sidebarPartial );
+				api.selectiveRefresh.trigger( 'sidebar-updated', sidebarPartial );
 			}
 
 			return sortedSidebarContainers;
@@ -333,16 +333,16 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 		 * @since 4.5.0
 		 *
 		 * @param {string} widgetId
-		 * @returns {wp.customize.Partial} Widget instance partial.
+		 * @returns {wp.customize.selectiveRefresh.Partial} Widget instance partial.
 		 */
 		ensureWidgetInstanceContainers: function( widgetId ) {
 			var sidebarPartial = this, widgetPartial, wasInserted = false, partialId = 'widget_instance[' + widgetId + ']';
-			widgetPartial = api.partial( partialId );
+			widgetPartial = api.selectiveRefresh.partial( partialId );
 			if ( ! widgetPartial ) {
 				widgetPartial = new self.WidgetInstancePartial( partialId, {
 					params: {}
 				} );
-				api.partial.add( widgetPartial.id, widgetPartial );
+				api.selectiveRefresh.partial.add( widgetPartial.id, widgetPartial );
 			}
 
 			// Make sure that there is a container element for the widget in the sidebar, if at least a placeholder.
@@ -410,7 +410,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 			// Handle removal of widgets.
 			widgetsRemoved = _.difference( oldWidgetIds, newWidgetIds );
 			_.each( widgetsRemoved, function( removedWidgetId ) {
-				var widgetPartial = api.partial( 'widget_instance[' + removedWidgetId + ']' );
+				var widgetPartial = api.selectiveRefresh.partial( 'widget_instance[' + removedWidgetId + ']' );
 				if ( widgetPartial ) {
 					_.each( widgetPartial.placements(), function( placement ) {
 						var isRemoved = (
@@ -435,7 +435,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 				widgetPartial.refresh();
 			} );
 
-			api.trigger( 'sidebar-updated', sidebarPartial );
+			api.selectiveRefresh.trigger( 'sidebar-updated', sidebarPartial );
 		},
 
 		/**
@@ -454,7 +454,7 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 				deferred.reject();
 			} else {
 				_.each( partial.reflowWidgets(), function( sidebarPlacement ) {
-					api.trigger( 'partial-content-rendered', sidebarPlacement );
+					api.selectiveRefresh.trigger( 'partial-content-rendered', sidebarPlacement );
 				} );
 				deferred.resolve();
 			}
@@ -463,8 +463,8 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 		}
 	});
 
-	api.partialConstructor.widget_area = self.WidgetAreaPartial;
-	api.partialConstructor.widget_instance = self.WidgetInstancePartial;
+	api.selectiveRefresh.partialConstructor.widget_area = self.WidgetAreaPartial;
+	api.selectiveRefresh.partialConstructor.widget_instance = self.WidgetInstancePartial;
 
 	/**
 	 * Add partials for the registered widget areas (sidebars).
@@ -474,14 +474,14 @@ wp.customize.widgetsPreview = wp.customize.WidgetCustomizerPreview = (function( 
 	self.addPartials = function() {
 		_.each( self.registeredSidebars, function( registeredSidebar ) {
 			var partial, partialId = 'widget_area[' + registeredSidebar.id + ']';
-			partial = api.partial( partialId );
+			partial = api.selectiveRefresh.partial( partialId );
 			if ( ! partial ) {
 				partial = new self.WidgetAreaPartial( partialId, {
 					params: {
 						sidebarArgs: registeredSidebar
 					}
 				} );
-				api.partial.add( partial.id, partial );
+				api.selectiveRefresh.partial.add( partial.id, partial );
 			}
 		} );
 	};

--- a/js/customize-selective-refresh.js
+++ b/js/customize-selective-refresh.js
@@ -817,7 +817,7 @@ wp.customize.selectiveRefresh = ( function( $, api ) {
 		 *
 		 * @param {api.selectiveRefresh.Placement} placement
 		 */
-		api.bind( 'partial-content-rendered', function( placement ) {
+		api.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 			if ( placement.container ) {
 				self.addPartials( placement.container );
 			}

--- a/js/plugin-support/jetpack.js
+++ b/js/plugin-support/jetpack.js
@@ -61,7 +61,7 @@ var customizeSelectiveRefreshJetpackModuleSupport = (function( api, $, exports )
 		/**
 		 * Get the widget ID base for a given partial.
 		 *
-		 * @param {wp.customize.Partial} partial
+		 * @param {wp.customize.selectiveRefresh.Partial} partial
 		 * @param {string}               partial.widgetId
 		 * @returns {string|null}
 		 */

--- a/js/plugin-support/jetpack.js
+++ b/js/plugin-support/jetpack.js
@@ -154,7 +154,7 @@ var customizeSelectiveRefreshJetpackModuleSupport = (function( api, $, exports )
 		 *
 		 * @param {api.selectiveRefresh.Placement} placement
 		 */
-		api.bind( 'partial-content-rendered', function( placement ) {
+		api.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 			var idBase = module.getWidgetPartialIdBase( placement.partial );
 			if ( idBase && module.widgetRenderHandlers[ idBase ] ) {
 				module.widgetRenderHandlers[ idBase ]( placement );
@@ -166,7 +166,7 @@ var customizeSelectiveRefreshJetpackModuleSupport = (function( api, $, exports )
 		 *
 		 * @param {api.selectiveRefresh.Placement} placement
 		 */
-		api.bind( 'partial-content-moved', function( placement ) {
+		api.selectiveRefresh.bind( 'partial-content-moved', function( placement ) {
 
 			// Refresh a partial containing a Twitter timeline iframe, since it has to be re-built.
 			if ( $( placement.container ).find( 'iframe.twitter-timeline:not([src]):first' ).length ) {
@@ -192,7 +192,7 @@ var customizeSelectiveRefreshJetpackModuleSupport = (function( api, $, exports )
 		 *
 		 * @param {api.selectiveRefresh.Placement} placement
 		 */
-		api.bind( 'partial-content-rendered', function( placement ) {
+		api.selectiveRefresh.bind( 'partial-content-rendered', function( placement ) {
 			var content = '';
 			if ( _.isString( placement.addedContent ) ) {
 				content = placement.addedContent;

--- a/js/theme-support/twentythirteen.js
+++ b/js/theme-support/twentythirteen.js
@@ -1,6 +1,6 @@
 /*global jQuery, wp */
 jQuery( function( $ ) {
-	wp.customize.bind( 'sidebar-updated', function( sidebarPartial ) {
+	wp.customize.selectiveRefresh.bind( 'sidebar-updated', function( sidebarPartial ) {
 		var widgetArea;
 		if ( 'sidebar-1' === sidebarPartial.sidebarId && $.isFunction( $.fn.masonry ) ) {
 			widgetArea = $( '#secondary .widget-area' );

--- a/php/class-wp-customize-partial.php
+++ b/php/class-wp-customize-partial.php
@@ -19,13 +19,13 @@
 class WP_Customize_Partial {
 
 	/**
-	 * Customize manager.
+	 * Component.
 	 *
 	 * @since 4.5.0
 	 * @access public
-	 * @var WP_Customize_Manager
+	 * @var WP_Customize_Selective_Refresh
 	 */
-	public $manager;
+	public $component;
 
 	/**
 	 * Unique identifier for the partial.
@@ -130,15 +130,15 @@ class WP_Customize_Partial {
 	 *
 	 * @since 4.5.0
 	 *
-	 * @param WP_Customize_Manager $manager Customize Partial Refresh plugin instance.
-	 * @param string               $id      Control ID.
-	 * @param array                $args    {
+	 * @param WP_Customize_Selective_Refresh $component Customize Partial Refresh plugin instance.
+	 * @param string                         $id        Control ID.
+	 * @param array                          $args      {
 	 *     Optional. Arguments to override class property defaults.
 	 *
 	 *     @type array|string  $settings        All settings IDs tied to the partial. If undefined, `$id` will be used.
 	 * }
 	 */
-	public function __construct( $manager, $id, $args = array() ) {
+	public function __construct( $component, $id, $args = array() ) {
 		$keys = array_keys( get_object_vars( $this ) );
 		foreach ( $keys as $key ) {
 			if ( isset( $args[ $key ] ) ) {
@@ -146,7 +146,7 @@ class WP_Customize_Partial {
 			}
 		}
 
-		$this->manager = $manager;
+		$this->component = $component;
 		$this->id = $id;
 		$this->id_data['keys'] = preg_split( '/\[/', str_replace( ']', '', $this->id ) );
 		$this->id_data['base'] = array_shift( $this->id_data['keys'] );

--- a/php/class-wp-customize-partial.php
+++ b/php/class-wp-customize-partial.php
@@ -138,7 +138,7 @@ class WP_Customize_Partial {
 	 *     @type array|string  $settings        All settings IDs tied to the partial. If undefined, `$id` will be used.
 	 * }
 	 */
-	public function __construct( $component, $id, $args = array() ) {
+	public function __construct( WP_Customize_Selective_Refresh $component, $id, $args = array() ) {
 		$keys = array_keys( get_object_vars( $this ) );
 		foreach ( $keys as $key ) {
 			if ( isset( $args[ $key ] ) ) {

--- a/php/class-wp-customize-selective-refresh.php
+++ b/php/class-wp-customize-selective-refresh.php
@@ -192,7 +192,7 @@ class WP_Customize_Selective_Refresh {
 			/** This filter (will be) documented in wp-includes/class-wp-customize-manager.php */
 			$class = apply_filters( 'customize_dynamic_partial_class', $class, $id, $args );
 
-			$partial = new $class( $this->manager, $id, $args );
+			$partial = new $class( $this, $id, $args );
 		}
 
 		$this->partials[ $partial->id ] = $partial;

--- a/tests/php/test-class-wp-customize-selective-refresh.php
+++ b/tests/php/test-class-wp-customize-selective-refresh.php
@@ -61,8 +61,7 @@ class Test_WP_Customize_Selective_Refresh extends WP_UnitTestCase {
 	 * @see WP_Customize_Selective_Refresh::__construct()
 	 */
 	function test_construct() {
-		$this->assertEquals( $this->wp_customize, $this->wp_customize->selective_refresh->manager );
-		$this->assertInstanceOf( 'WP_Customize_Manager', $this->wp_customize->selective_refresh->manager );
+		$this->assertEquals( $this->selective_refresh, $this->wp_customize->selective_refresh );
 	}
 
 	/**
@@ -117,7 +116,7 @@ class Test_WP_Customize_Selective_Refresh extends WP_UnitTestCase {
 	 */
 	function test_crud_partial() {
 		$partial = $this->selective_refresh->add_partial( 'foo' );
-		$this->assertEquals( $this->wp_customize, $partial->manager );
+		$this->assertEquals( $this->selective_refresh, $partial->component );
 		$this->assertInstanceOf( 'WP_Customize_Partial', $partial );
 		$this->assertEquals( $partial, $this->selective_refresh->get_partial( $partial->id ) );
 		$this->assertArrayHasKey( $partial->id, $this->selective_refresh->partials() );
@@ -126,7 +125,7 @@ class Test_WP_Customize_Selective_Refresh extends WP_UnitTestCase {
 		$this->assertEmpty( $this->selective_refresh->get_partial( $partial->id ) );
 		$this->assertArrayNotHasKey( $partial->id, $this->selective_refresh->partials() );
 
-		$partial = new WP_Customize_Partial( $this->wp_customize, 'bar' );
+		$partial = new WP_Customize_Partial( $this->selective_refresh, 'bar' );
 		$this->assertEquals( $partial, $this->selective_refresh->add_partial( $partial ) );
 		$this->assertEquals( $partial, $this->selective_refresh->get_partial( 'bar' ) );
 		$this->assertEqualSets( array( 'bar' ), array_keys( $this->selective_refresh->partials() ) );


### PR DESCRIPTION
I'm not 100% certain on this, but I think this is better, to stop adding stuff to `wp.customize` directly, to use the PHP component object as the dependency as opposed to the root manager. 

Note that plugins would then listen to events via `wp.customize.selectiveRefresh.bind( 'sidebar-updated', function(){ ... } )` instead of binding on the root `wp.customize`.